### PR TITLE
Adding persistent notifications in case of errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Also, you need to **change the redirect URI** compared to before: replace `.../a
 homeconnect:
   client_id: YOUR_CLIENT_ID
   client_secret: YOUR_CLIENT_SECRET
+  show_notifications: true|false  (will show program start errors as persistent notifications. Default = true)
 ```
 5. Copy the contents of `custom_components` to the  `custom_components` directory of your Home Assistant configuration directory
 6. Navigate to the Integrations page and select "Home Connect"

--- a/custom_components/homeconnect/__init__.py
+++ b/custom_components/homeconnect/__init__.py
@@ -19,7 +19,7 @@ from homeassistant.helpers import config_entry_oauth2_flow, config_validation as
 from homeassistant.util import Throttle
 
 from . import api, config_flow
-from .const import DOMAIN, OAUTH2_AUTHORIZE, OAUTH2_TOKEN
+from .const import DOMAIN, OAUTH2_AUTHORIZE, OAUTH2_TOKEN, CONF_SHOW_NOTIFICATIONS
 
 os.environ["OAUTHLIB_INSECURE_TRANSPORT"] = "1"
 
@@ -33,6 +33,7 @@ CONFIG_SCHEMA = vol.Schema(
             {
                 vol.Required(CONF_CLIENT_ID): cv.string,
                 vol.Required(CONF_CLIENT_SECRET): cv.string,
+                vol.Optional(CONF_SHOW_NOTIFICATIONS, default=True): cv.boolean,
             }
         )
     },
@@ -48,6 +49,8 @@ async def async_setup(hass: HomeAssistant, config: dict, add_entities=None):
 
     if DOMAIN not in config:
         return True
+
+    hass.data[DOMAIN][CONF_SHOW_NOTIFICATIONS] = config[DOMAIN][CONF_SHOW_NOTIFICATIONS]
 
     config_flow.OAuth2FlowHandler.async_register_implementation(
         hass,
@@ -70,9 +73,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
         hass, entry
     )
 
-    hc_api = api.ConfigEntryAuth(hass, entry, implementation)
-
-    hass.data[DOMAIN][entry.entry_id] = hc_api
+    hass.data[DOMAIN][entry.entry_id] = api.ConfigEntryAuth(hass, entry, implementation)
 
     await update_all_devices(hass, entry)
 

--- a/custom_components/homeconnect/const.py
+++ b/custom_components/homeconnect/const.py
@@ -4,3 +4,5 @@ DOMAIN = "homeconnect"
 
 OAUTH2_AUTHORIZE = "https://api.home-connect.com/security/oauth/authorize"
 OAUTH2_TOKEN = "https://api.home-connect.com/security/oauth/token"
+
+CONF_SHOW_NOTIFICATIONS = "show_notifications"

--- a/custom_components/homeconnect/switch.py
+++ b/custom_components/homeconnect/switch.py
@@ -12,7 +12,7 @@ from homeconnect.api import HomeConnectError
 from homeassistant.components.switch import SwitchDevice
 
 from .api import HomeConnectEntity
-from .const import DOMAIN
+from .const import DOMAIN, CONF_SHOW_NOTIFICATIONS
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -68,10 +68,12 @@ class HomeConnectProgramSwitch(HomeConnectEntity, SwitchDevice):
             self.device.appliance.start_program(self.program_name)
         except HomeConnectError as err:
             error = json.loads(str(err).replace("'", '"'))
-            self._hass.components.persistent_notification.create(
-                'Key: {}<br>Description: <strong>{}</strong>'.format(error["key"], error["description"]),
-                title='Error while trying to start program: {}'.format(self.program_name),
-                notification_id='homeconnect_notification')
+
+            if self._hass.data[DOMAIN][CONF_SHOW_NOTIFICATIONS]:
+                self._hass.components.persistent_notification.create(
+                    'Key: {}<br>Description: <strong>{}</strong>'.format(error["key"], error["description"]),
+                    title='Error while trying to start program: {}'.format(self.program_name),
+                    notification_id='homeconnect_notification')
 
             _LOGGER.error("Error while trying to start program: %s", err)
         self.async_entity_update()


### PR DESCRIPTION
With this PR I want to suggest a couple of improvements:

1. _Select the program before starting it._
    I think it's helpful since sometimes, if the program doesn't start for some reason (ex: remote start not enabled!), you can't see anything in the physical device showing that the command was running.

2. _Show a persistent notification when the program could not be started_
   For example, when remote start is not enabled, you won't see any warning/error and you can't realize the program didn't start. At least, with this code, you'll see there was an error.

**TODO**:
- customize if you want to receive notifications with an on/off flag in integration configuration